### PR TITLE
NEW: Compress textures by default (new switch to disable).

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
@@ -212,6 +212,11 @@ namespace UnityGLTF
 		/// </summary>
 		public bool CullFarLOD = false;
 
+        /// <summary>
+        /// Whether to run <c>Texture2D.Compress(true)</c> on textures.
+        /// </summary>
+        public bool CompressTextures = true;
+
 		/// <summary>
 		/// Statistics from the scene
 		/// </summary>

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneImporter.cs
@@ -212,10 +212,10 @@ namespace UnityGLTF
 		/// </summary>
 		public bool CullFarLOD = false;
 
-        /// <summary>
-        /// Whether to run <c>Texture2D.Compress(true)</c> on textures.
-        /// </summary>
-        public bool CompressTextures = true;
+		/// <summary>
+		/// Whether to run <c>Texture2D.Compress(true)</c> on textures.
+		/// </summary>
+		public bool CompressTextures = true;
 
 		/// <summary>
 		/// Statistics from the scene

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
@@ -86,7 +86,7 @@ namespace UnityGLTF
 				if (pbr.BaseColorTexture != null)
 				{
 					TextureId textureId = pbr.BaseColorTexture.Index;
-                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
+					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					mrMapper.BaseColorTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					mrMapper.BaseColorTexCoord = pbr.BaseColorTexture.TexCoord;
 
@@ -110,7 +110,7 @@ namespace UnityGLTF
 				if (pbr.MetallicRoughnessTexture != null)
 				{
 					TextureId textureId = pbr.MetallicRoughnessTexture.Index;
-                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true, CompressTextures);
+					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true, CompressTextures);
 					mrMapper.MetallicRoughnessTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					mrMapper.MetallicRoughnessTexCoord = pbr.MetallicRoughnessTexture.TexCoord;
 
@@ -141,7 +141,7 @@ namespace UnityGLTF
 				if (specGloss.DiffuseTexture != null)
 				{
 					TextureId textureId = specGloss.DiffuseTexture.Index;
-                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
+					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					sgMapper.DiffuseTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					sgMapper.DiffuseTexCoord = specGloss.DiffuseTexture.TexCoord;
 
@@ -161,7 +161,7 @@ namespace UnityGLTF
 				if (specGloss.SpecularGlossinessTexture != null)
 				{
 					TextureId textureId = specGloss.SpecularGlossinessTexture.Index;
-                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
+					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					sgMapper.SpecularGlossinessTexture = _assetCache.TextureCache[textureId.Id].Texture;
 
 					var ext = GetTextureTransform(specGloss.SpecularGlossinessTexture);
@@ -184,7 +184,7 @@ namespace UnityGLTF
 				if (pbr.BaseColorTexture != null)
 				{
 					TextureId textureId = pbr.BaseColorTexture.Index;
-                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
+					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					unlitMapper.BaseColorTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					unlitMapper.BaseColorTexCoord = pbr.BaseColorTexture.TexCoord;
 
@@ -286,7 +286,7 @@ namespace UnityGLTF
 				if (def.NormalTexture != null)
 				{
 					TextureId textureId = def.NormalTexture.Index;
-                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true, CompressTextures);
+					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true, CompressTextures);
 					uniformMapper.NormalTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					uniformMapper.NormalTexCoord = def.NormalTexture.TexCoord;
 					uniformMapper.NormalTexScale = def.NormalTexture.Scale;
@@ -305,8 +305,8 @@ namespace UnityGLTF
 				{
 					uniformMapper.OcclusionTexStrength = def.OcclusionTexture.Strength;
 					TextureId textureId = def.OcclusionTexture.Index;
-                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true,
-                        CompressTextures);
+					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true,
+						CompressTextures);
 					uniformMapper.OcclusionTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					uniformMapper.OcclusionTexCoord = def.OcclusionTexture.TexCoord;
 
@@ -328,7 +328,7 @@ namespace UnityGLTF
 				if (def.EmissiveTexture != null)
 				{
 					TextureId textureId = def.EmissiveTexture.Index;
-                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
+					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					uniformMapper.EmissiveTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					uniformMapper.EmissiveTexCoord = def.EmissiveTexture.TexCoord;
 
@@ -516,7 +516,7 @@ namespace UnityGLTF
 		protected virtual KHR_materials_emissive_strength GetEmissiveStrength(GLTFMaterial def)
 		{
 			if (_gltfRoot.ExtensionsUsed != null && _gltfRoot.ExtensionsUsed.Contains(KHR_materials_emissive_strength_Factory.EXTENSION_NAME) &&
-			    def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_emissive_strength_Factory.EXTENSION_NAME, out var extension))
+				def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_emissive_strength_Factory.EXTENSION_NAME, out var extension))
 			{
 				return (KHR_materials_emissive_strength) extension;
 			}
@@ -526,7 +526,7 @@ namespace UnityGLTF
 		protected virtual KHR_materials_transmission GetTransmission(GLTFMaterial def)
 		{
 			if (_gltfRoot.ExtensionsUsed != null && _gltfRoot.ExtensionsUsed.Contains(KHR_materials_transmission_Factory.EXTENSION_NAME) &&
-			    def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_transmission_Factory.EXTENSION_NAME, out var extension))
+				def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_transmission_Factory.EXTENSION_NAME, out var extension))
 			{
 				return (KHR_materials_transmission) extension;
 			}
@@ -536,7 +536,7 @@ namespace UnityGLTF
 		protected virtual KHR_materials_volume GetVolume(GLTFMaterial def)
 		{
 			if (_gltfRoot.ExtensionsUsed != null && _gltfRoot.ExtensionsUsed.Contains(KHR_materials_volume_Factory.EXTENSION_NAME) &&
-			    def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_volume_Factory.EXTENSION_NAME, out var extension))
+				def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_volume_Factory.EXTENSION_NAME, out var extension))
 			{
 				return (KHR_materials_volume) extension;
 			}
@@ -546,7 +546,7 @@ namespace UnityGLTF
 		protected virtual KHR_materials_ior GetIOR(GLTFMaterial def)
 		{
 			if (_gltfRoot.ExtensionsUsed != null && _gltfRoot.ExtensionsUsed.Contains(KHR_materials_ior_Factory.EXTENSION_NAME) &&
-			    def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_ior_Factory.EXTENSION_NAME, out var extension))
+				def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_ior_Factory.EXTENSION_NAME, out var extension))
 			{
 				return (KHR_materials_ior) extension;
 			}
@@ -556,7 +556,7 @@ namespace UnityGLTF
 		protected virtual KHR_materials_iridescence GetIridescence(GLTFMaterial def)
 		{
 			if (_gltfRoot.ExtensionsUsed != null && _gltfRoot.ExtensionsUsed.Contains(KHR_materials_iridescence_Factory.EXTENSION_NAME) &&
-			    def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_iridescence_Factory.EXTENSION_NAME, out var extension))
+				def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_iridescence_Factory.EXTENSION_NAME, out var extension))
 			{
 				return (KHR_materials_iridescence) extension;
 			}
@@ -566,7 +566,7 @@ namespace UnityGLTF
 		protected virtual KHR_materials_specular GetSpecular(GLTFMaterial def)
 		{
 			if (_gltfRoot.ExtensionsUsed != null && _gltfRoot.ExtensionsUsed.Contains(KHR_materials_specular_Factory.EXTENSION_NAME) &&
-			    def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_specular_Factory.EXTENSION_NAME, out var extension))
+				def.Extensions != null && def.Extensions.TryGetValue(KHR_materials_specular_Factory.EXTENSION_NAME, out var extension))
 			{
 				return (KHR_materials_specular) extension;
 			}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMaterials.cs
@@ -86,7 +86,7 @@ namespace UnityGLTF
 				if (pbr.BaseColorTexture != null)
 				{
 					TextureId textureId = pbr.BaseColorTexture.Index;
-					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false);
+                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					mrMapper.BaseColorTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					mrMapper.BaseColorTexCoord = pbr.BaseColorTexture.TexCoord;
 
@@ -110,7 +110,7 @@ namespace UnityGLTF
 				if (pbr.MetallicRoughnessTexture != null)
 				{
 					TextureId textureId = pbr.MetallicRoughnessTexture.Index;
-					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true);
+                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true, CompressTextures);
 					mrMapper.MetallicRoughnessTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					mrMapper.MetallicRoughnessTexCoord = pbr.MetallicRoughnessTexture.TexCoord;
 
@@ -141,7 +141,7 @@ namespace UnityGLTF
 				if (specGloss.DiffuseTexture != null)
 				{
 					TextureId textureId = specGloss.DiffuseTexture.Index;
-					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false);
+                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					sgMapper.DiffuseTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					sgMapper.DiffuseTexCoord = specGloss.DiffuseTexture.TexCoord;
 
@@ -161,7 +161,7 @@ namespace UnityGLTF
 				if (specGloss.SpecularGlossinessTexture != null)
 				{
 					TextureId textureId = specGloss.SpecularGlossinessTexture.Index;
-					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false);
+                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					sgMapper.SpecularGlossinessTexture = _assetCache.TextureCache[textureId.Id].Texture;
 
 					var ext = GetTextureTransform(specGloss.SpecularGlossinessTexture);
@@ -184,7 +184,7 @@ namespace UnityGLTF
 				if (pbr.BaseColorTexture != null)
 				{
 					TextureId textureId = pbr.BaseColorTexture.Index;
-					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false);
+                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					unlitMapper.BaseColorTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					unlitMapper.BaseColorTexCoord = pbr.BaseColorTexture.TexCoord;
 
@@ -286,7 +286,7 @@ namespace UnityGLTF
 				if (def.NormalTexture != null)
 				{
 					TextureId textureId = def.NormalTexture.Index;
-					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true);
+                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true, CompressTextures);
 					uniformMapper.NormalTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					uniformMapper.NormalTexCoord = def.NormalTexture.TexCoord;
 					uniformMapper.NormalTexScale = def.NormalTexture.Scale;
@@ -305,7 +305,8 @@ namespace UnityGLTF
 				{
 					uniformMapper.OcclusionTexStrength = def.OcclusionTexture.Strength;
 					TextureId textureId = def.OcclusionTexture.Index;
-					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true);
+                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true,
+                        CompressTextures);
 					uniformMapper.OcclusionTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					uniformMapper.OcclusionTexCoord = def.OcclusionTexture.TexCoord;
 
@@ -327,7 +328,7 @@ namespace UnityGLTF
 				if (def.EmissiveTexture != null)
 				{
 					TextureId textureId = def.EmissiveTexture.Index;
-					await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false);
+                    await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, false, CompressTextures);
 					uniformMapper.EmissiveTexture = _assetCache.TextureCache[textureId.Id].Texture;
 					uniformMapper.EmissiveTexCoord = def.EmissiveTexture.TexCoord;
 

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterTextures.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterTextures.cs
@@ -29,7 +29,7 @@ namespace UnityGLTF
 			if (textureInfo?.Index?.Value == null) return result;
 
 			TextureId textureId = textureInfo.Index;
-            await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true, CompressTextures);
+			await ConstructTexture(textureId.Value, textureId.Id, !KeepCPUCopyOfTexture, true, CompressTextures);
 			result.Texture = _assetCache.TextureCache[textureId.Id].Texture;
 			result.TexCoord = textureInfo.TexCoord;
 
@@ -50,7 +50,7 @@ namespace UnityGLTF
 			return result;
 		}
 
-        protected async Task ConstructImage(GLTFImage image, int imageCacheIndex, bool markGpuOnly, bool isLinear, bool compress)
+		protected async Task ConstructImage(GLTFImage image, int imageCacheIndex, bool markGpuOnly, bool isLinear, bool compress)
 		{
 			if (_assetCache.ImageCache[imageCacheIndex] == null)
 			{
@@ -81,7 +81,7 @@ namespace UnityGLTF
 				}
 
 				await YieldOnTimeoutAndThrowOnLowMemory();
-                await ConstructUnityTexture(stream, markGpuOnly, isLinear, compress, image, imageCacheIndex);
+				await ConstructUnityTexture(stream, markGpuOnly, isLinear, compress, image, imageCacheIndex);
 			}
 		}
 
@@ -113,14 +113,14 @@ namespace UnityGLTF
 			}
 		}
 
-        async Task CheckMimeTypeAndLoadImage(GLTFImage image, Texture2D texture, byte[] data, bool markGpuOnly, bool compress)
+		async Task CheckMimeTypeAndLoadImage(GLTFImage image, Texture2D texture, byte[] data, bool markGpuOnly, bool compress)
 		{
 			switch (image.MimeType)
 			{
 				case "image/png":
 				case "image/jpeg":
 					//	NOTE: the second parameter of LoadImage() marks non-readable, but we can't mark it until after we call Apply()
-                    texture.LoadImage(data, markNonReadable: false);
+					texture.LoadImage(data, markNonReadable: false);
 					break;
 				case "image/ktx2":
 #if HAVE_KTX
@@ -139,18 +139,18 @@ namespace UnityGLTF
 #endif
 					break;
 				default:
-                    texture.LoadImage(data, markNonReadable: false);
+					texture.LoadImage(data, markNonReadable: false);
 					break;
 			}
-            if (compress)
-                texture.Compress(true);
-            if (markGpuOnly)
-                texture.Apply(updateMipmaps: false, makeNoLongerReadable: true);
+			if (compress)
+				texture.Compress(true);
+			if (markGpuOnly)
+				texture.Apply(updateMipmaps: false, makeNoLongerReadable: true);
 
 			await Task.CompletedTask;
 		}
 
-        protected virtual async Task ConstructUnityTexture(Stream stream, bool markGpuOnly, bool isLinear, bool compress, GLTFImage image, int imageCacheIndex)
+		protected virtual async Task ConstructUnityTexture(Stream stream, bool markGpuOnly, bool isLinear, bool compress, GLTFImage image, int imageCacheIndex)
 		{
 #if UNITY_EDITOR
 			if (stream is AssetDatabaseStream assetDatabaseStream)
@@ -170,7 +170,7 @@ namespace UnityGLTF
 				using (MemoryStream memoryStream = stream as MemoryStream)
 				{
 					await YieldOnTimeoutAndThrowOnLowMemory();
-                    await CheckMimeTypeAndLoadImage(image, texture, memoryStream.ToArray(), markGpuOnly, compress);
+					await CheckMimeTypeAndLoadImage(image, texture, memoryStream.ToArray(), markGpuOnly, compress);
 				}
 			}
 			else
@@ -185,7 +185,7 @@ namespace UnityGLTF
 				stream.Read(buffer, 0, (int)stream.Length);
 
 				await YieldOnTimeoutAndThrowOnLowMemory();
-                await CheckMimeTypeAndLoadImage(image, texture, buffer, markGpuOnly, compress);
+				await CheckMimeTypeAndLoadImage(image, texture, buffer, markGpuOnly, compress);
 			}
 
 			if (_assetCache.ImageCache[imageCacheIndex] != null) Debug.Log(LogType.Assert, "ImageCache should not be loaded multiple times");
@@ -208,7 +208,7 @@ namespace UnityGLTF
 		/// <param name="markGpuOnly">Whether the texture is GPU only, instead of keeping a CPU copy</param>
 		/// <param name="isLinear">Whether the texture is linear rather than sRGB</param>
 		/// <returns>The loading task</returns>
-        public virtual async Task LoadTextureAsync(GLTFTexture texture, int textureIndex, bool markGpuOnly, bool isLinear, bool compress)
+		public virtual async Task LoadTextureAsync(GLTFTexture texture, int textureIndex, bool markGpuOnly, bool isLinear, bool compress)
 		{
 			try
 			{
@@ -238,7 +238,7 @@ namespace UnityGLTF
 				}
 
 				await ConstructImageBuffer(texture, textureIndex);
-                await ConstructTexture(texture, textureIndex, markGpuOnly, isLinear, compress);
+				await ConstructTexture(texture, textureIndex, markGpuOnly, isLinear, compress);
 			}
 			finally
 			{
@@ -249,9 +249,9 @@ namespace UnityGLTF
 			}
 		}
 
-        public virtual Task LoadTextureAsync(GLTFTexture texture, int textureIndex, bool isLinear, bool compress)
+		public virtual Task LoadTextureAsync(GLTFTexture texture, int textureIndex, bool isLinear, bool compress)
 		{
-            return LoadTextureAsync(texture, textureIndex, !KeepCPUCopyOfTexture, isLinear, compress);
+			return LoadTextureAsync(texture, textureIndex, !KeepCPUCopyOfTexture, isLinear, compress);
 		}
 
 		/// <summary>
@@ -274,13 +274,13 @@ namespace UnityGLTF
 			return _assetCache.TextureCache[textureIndex].Texture;
 		}
 
-        protected virtual async Task ConstructTexture(GLTFTexture texture, int textureIndex, bool markGpuOnly, bool isLinear, bool compress)
+		protected virtual async Task ConstructTexture(GLTFTexture texture, int textureIndex, bool markGpuOnly, bool isLinear, bool compress)
 		{
 			if (_assetCache.TextureCache[textureIndex].Texture == null)
 			{
 				int sourceId = GetTextureSourceId(texture);
 				GLTFImage image = _gltfRoot.Images[sourceId];
-                await ConstructImage(image, sourceId, markGpuOnly, isLinear, compress);
+				await ConstructImage(image, sourceId, markGpuOnly, isLinear, compress);
 
 				var source = _assetCache.ImageCache[sourceId];
 				FilterMode desiredFilterMode;


### PR DESCRIPTION
Adds a new switch to enable runtime compression of textures. Enabled by default.

Did not notice any significant increase in loading times.